### PR TITLE
futhark internal error

### DIFF
--- a/feigenbaum.fut
+++ b/feigenbaum.fut
@@ -92,7 +92,7 @@ module lys: lys with text_content = text_content = {
 
   let sysdef_feigen_interp : sysdef stmt.rfile =
     {kind=#feigen_interp,
-     init=stmt.set (stmt.emp 0.0) stmt.ax 0.25,
+     init=let rf = stmt.emp 0.0 in stmt.set rf stmt.ax 0.25,
      prj=\rf -> stmt.get rf stmt.ax,
      next=\a rf -> let ss = stmt.([#sto bx,       -- bx <- ax
 				   #f64 1.0,      -- ax <- 1.0


### PR DESCRIPTION
Here is what happens:

````
bash-3.2$ futhark --version
Futhark 0.14.1
Copyright (C) DIKU, University of Copenhagen, released under the ISC license.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
bash-3.2$ make
cat lib/github.com/diku-dk/lys/genlys.fut | sed 's/"lys"/"feigenbaum"/' > feigenbaum_wrapper.fut
futhark opencl --library feigenbaum_wrapper.fut
Internal compiler error.
Please report this at https://github.com/diku-dk/futhark/issues.
After internalisation:
In function lifted_1_next_5475
Type error:
rf_13270 was invalidly consumed.
Nothing can be consumed here.

make: *** [feigenbaum_wrapper.c] Error 2
rm feigenbaum_wrapper.fut
bash-3.2$ 
````